### PR TITLE
Fix failure when no changes are detected

### DIFF
--- a/git-travis-change
+++ b/git-travis-change
@@ -8,7 +8,7 @@ CHECK_PATH=$1'/'
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     # This is PR
     echo "Checking changes since ${TRAVIS_COMMIT_RANGE} against ${CHECK_PATH}"
-    GITDIFF=`git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep ${CHECK_PATH} | tr -d '[:space:]'`
+    GITDIFF=`git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep ${CHECK_PATH} || true | tr -d '[:space:]'`
     if [ "$GITDIFF" == "" ]; then
         echo "No code changes, skipped script"
         exit 0


### PR DESCRIPTION
Sometimes git diff would fail. We want to detect this case so pipefail is enabled. However, grep would exit with non-zero code if no match and trigger pipefail. To workaround this, forcefully set grep exit code to zero using `true`.